### PR TITLE
Added Circat.FFT.

### DIFF
--- a/circat.cabal
+++ b/circat.cabal
@@ -52,6 +52,7 @@ Library
                     Circat.Netlist
                     Circat.ShowUtils
                     Circat.Prim
+                    Circat.FFT
   Other-Modules:
                     Circat.Examples
 

--- a/src/Circat/Circuit.hs
+++ b/src/Circat/Circuit.hs
@@ -200,6 +200,8 @@ newSource w prim ins o = (\ b -> Source b prim ins o) <$> newBus w
 --------------------------------------------------------------------}
 
 -- | Typed aggregate of buses. @'Buses' a@ carries a value of type @a@.
+-- @IsoB@ is the isomorphic form. Note: b must not have one of the standard forms.
+-- If it does, we'll get a run-time error when consuming.
 data Buses :: * -> * where
   UnitB   :: Buses Unit
   BoolB   :: Source -> Buses Bool
@@ -207,8 +209,6 @@ data Buses :: * -> * where
   DoubleB :: Source -> Buses Double
   PairB   :: Buses a -> Buses b -> Buses (a :* b)
   FunB    :: (a :> b) -> Buses (a -> b)
-  -- | Isomorphic form. Note: b must not have one of the standard forms.
-  -- If it does, we'll get a run-time error when consuming.
   IsoB    :: Buses (Rep a) -> Buses a
 
 instance Eq (Buses a) where

--- a/src/Circat/FFT.hs
+++ b/src/Circat/FFT.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+----------------------------------------------------------------------
+-- |
+-- Module      :  Circat.FFT
+-- Copyright   :  (c) 2015 David Banas
+-- License     :  BSD3
+-- 
+-- Maintainer  :  capn.freako@gmail.com
+-- Stability   :  experimental
+-- 
+-- Fast Fourier Transform (FFT), as a class, via Circat
+----------------------------------------------------------------------
+
+module Circat.FFT where
+
+import Prelude hiding ({- id,(.), -}foldl,foldr,sum,product,zipWith,reverse,and,or,scanl,minimum,maximum)
+
+import Control.Applicative
+import Control.Arrow
+import Data.Complex
+import Data.Foldable (Foldable, sum, foldl')
+import TypeUnary.Nat (IsNat, Nat(..), nat, N2, N3, N4, N5)  -- , N6)
+
+import Circat.Scan (lproducts, LScan)
+import qualified Circat.Pair as P
+import qualified Circat.RTree as RT
+import Circat.RTree (bottomSplit)
+
+type RTree = RT.Tree
+
+-- | FFT, as a class
+-- (The LScan constraint comes from the use of 'lproducts', in 'addPhase'.)
+class (LScan f) => FFT f a where
+    fft  :: f a -> f a  -- ^ Computes the FFT of a functor.
+
+-- Note that this definition of the FFT instance for Pair assumes DIT.
+-- How can we eliminate this assumption and make this more general?
+instance (RealFloat a, Applicative f, Foldable f, Num (f (Complex a)), FFT f (Complex a)) => FFT P.Pair (f (Complex a)) where
+    fft = P.inP (uncurry (+) &&& uncurry (-)) . P.secondP addPhase . fmap fft
+
+instance (IsNat n, RealFloat a) => FFT (RTree n) (Complex a) where
+    fft = fft' nat
+        where   fft' :: (RealFloat a) => Nat n -> RTree n (Complex a) -> RTree n (Complex a)
+                fft' Zero     = id
+                fft' (Succ _) = inDIT fft
+                    where   inDIT g  = RT.toB . g . bottomSplit
+
+-- | Adds the proper phase adjustments to a functor containing Complex RealFloats,
+-- and instancing Num.
+addPhase :: (Applicative f, Foldable f, LScan f, RealFloat a, Num (f (Complex a))) => f (Complex a) -> f (Complex a)
+addPhase = liftA2 (*) id phasor
+  where phasor f = fst $ lproducts (pure phaseDelta)
+          where phaseDelta = cis ((-pi) / fromIntegral n)
+                n          = flen f
+
+-- | Gives the "length" (i.e. - number of elements in) of a Foldable.
+-- (Soon, to be provided by the Foldable class, as "length".)
+flen :: (Foldable f) => f a -> Int
+flen = foldl' (flip ((+) . const 1)) 0
+


### PR DESCRIPTION
Conal,

It seemed to me that _FFT, as a class, and via *Circat*_ belonged as a submodule of _Circat_ itself.
If you disagree with this choice, PLEASE, let me know; I'm not married to it, by any means. :)

The change to the comment structure of _Circat.Circuit_ is the result of me struggling to get through a _Haddock_ build, which runs as a result of:

    $ stack build --haddock fft-ccc

I tried several alternatives, which all kept your original comments lexically adjacent to the _IsoB_ type definition, but none worked. Any thoughts on this? It seems rather strange.

Thanks,
-db
